### PR TITLE
Add test kitchen configuration with installed Habitat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ build-iPhoneSimulator/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+.kitchen

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,23 @@
+---
+driver:
+  name: vagrant
+  network:
+    - ["forwarded_port", {guest: 9631, host: 9631}]
+    - ["forwarded_port", {guest: 9632, host: 9632}]
+
+provisioner:
+  name: shell
+
+verifier:
+  name: inspec
+
+platforms:
+  - name: centos-7.5
+
+suites:
+  - name: inspec-habitat
+    provisioner:
+      arguments: []
+    verifier:
+      inspect_tests:
+        test/integration/inspec-habitat

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # inspec-habitat
+
+## Dev
+
+Habitat and the Habitat Supervisor have been provided in a kitchen VM. To start simply run `kitchen converge`.
+
+## Testing
+
+Tests are located in `test/integration/inspec-habitat` and may be run using `kitchen verify`.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if [ ! -e "/bin/hab" ]; then
+  curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | sudo bash
+fi
+
+if grep "hab" /etc/passwd > /dev/null; then
+  echo "Hab user exists"
+else
+  useradd hab && true
+fi
+
+if grep "hab" /etc/group > /dev/null; then
+  echo "Hab group exists"
+else
+  groupadd hab && true
+fi
+
+hab pkg install core/hab-sup

--- a/test/integration/inspec-habitat/base_test.rb
+++ b/test/integration/inspec-habitat/base_test.rb
@@ -1,0 +1,8 @@
+# # encoding: utf-8
+
+# The Inspec reference, with examples and extensive documentation, can be
+# found at http://inspec.io/docs/reference/resources/
+
+describe directory('/hab/pkgs/core/hab-sup') do
+  it { should exist }
+end


### PR DESCRIPTION
This adds a kitchen config using CentOS 7.5 and vagrant.
- Habitat CLI and Habitat Supervisor are installed during bootstrap
- Port forwards are included for `http-gateway` and `ctl-gateway`

Signed-off-by: Joshua Padgett <jpadgett@chef.io>