### PR TITLE
Update references from inspec 3 to inspec 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,5 @@ group :development do
 end
 
 group :inspec do
-  gem 'inspec', '~> 3.9'
+  gem 'inspec-bin', '~> 4.7'
 end

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Example inspec.yml:
 name: my-profile
 title: My own Hab profile
 version: 0.1.0
-inspec_version: '>= 3.8.0'
+inspec_version: '>= 4.7.3'
 depends:
   - name: inspec-habitat
     url: https://github.com/inspec/inspec-habitat/archive/master.tar.gz

--- a/inspec.yml
+++ b/inspec.yml
@@ -6,6 +6,6 @@ copyright_email: support@chef.io
 license: Apache-2.0
 summary: This resource pack provides compliance resources for Habitat.
 version: 1.0.2
-inspec_version: '>= 3.0.0'
+inspec_version: '>= 4.7.3'
 supports:
   - platform: habitat


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

The Gemfile had it pinned to less than 3, which only affected development; but the inspec.yml said 3+ and the README said 3.8+, both of which could actively do harm. I've added 4.7+ in those places.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
