### PR TITLE
Update require location of filtertable for requires in plural resources

### DIFF
--- a/libraries/habitat_packages.rb
+++ b/libraries/habitat_packages.rb
@@ -1,4 +1,4 @@
-require 'utils/filter'
+require 'inspec/utils/filter'
 require 'inspec/exceptions'
 
 class HabitatPackages < Inspec.resource(1)

--- a/libraries/habitat_services.rb
+++ b/libraries/habitat_services.rb
@@ -1,4 +1,4 @@
-require 'utils/filter'
+require 'inspec/utils/filter'
 
 class HabitatServices < Inspec.resource(1)
   name 'habitat_services'


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

We moved the `utils` directory in the inspec repo, so when a resource pack requires a file across a repo boundary (!!!) that broke. 

This fixes that; this is more correct.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes #40 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
