### PR TITLE
migrate inspec resources docs from inspec/inspec repo

### DIFF
--- a/docs/go.mod
+++ b/docs/go.mod
@@ -1,0 +1,3 @@
+module github.com/inspec/inspec-habitat/docs
+
+go 1.14

--- a/docs/resources/habitat_package.md
+++ b/docs/resources/habitat_package.md
@@ -1,9 +1,16 @@
----
-title: About the habitat_package Resource
-platform: habitat
----
++++
+title = "habitat_package resource"
+draft = false
+platform = "habitat"
 
-# habitat_package
+[menu]
+  [menu.inspec]
+    title = "habitat_package"
+    identifier = "inspec/resources/habitat/habitat_package.md habitat_package resource"
+    parent = "inspec/resources/habitat"
++++
+
+[\[edit on GitHub\]](https://github.com/inspec/inspec-habitat/blob/master/docs/resources/habitat_package.md)
 
 Use the `habitat_package` InSpec audit resource to test properties of a single Habitat package.
 
@@ -43,12 +50,12 @@ If you use the API interface without the CLI, instances of this resource will be
 
 If the package is not found, then this resource behaves as follows:
 
- * `it { should exist }` will be a failing test. Check this test if you are unsure if the resource will exist; it is guaranteed to be reliable in the future.
- * `name`, `origin`, `version`, and `release` will continue to return their values as set in the resource parameters. This allows output messaging to refer to the missing package clearly.
- * `identifier` will return as much information as it can assemble from `name`, `origin`, `version`, and `release`.
- * All other single-value properties will return `nil`.
- * All array- and hash-valued properties will return empty objects.
- * All matchers will return `false`.
+- `it { should exist }` will be a failing test. Check this test if you are unsure if the resource will exist; it is guaranteed to be reliable in the future.
+- `name`, `origin`, `version`, and `release` will continue to return their values as set in the resource parameters. This allows output messaging to refer to the missing package clearly.
+- `identifier` will return as much information as it can assemble from `name`, `origin`, `version`, and `release`.
+- All other single-value properties will return `nil`.
+- All array- and hash-valued properties will return empty objects.
+- All matchers will return `false`.
 
 ### Behavior when multiple packages match
 
@@ -70,7 +77,7 @@ This resource was first available in version 0.1.0 of the resource pack.
 
 ## Resource Parameters
 
-Use [resource parameters](https://www.inspec.io/docs/reference/glossary/#resource-parameter) to identify the particular package you wish to test.
+Use [resource parameters](/inspec/glossary/#resource-parameter) to identify the particular package you wish to test.
 
 `habitat_package` can accept a single resource parameter, a `String` package identifier; or it can accept a `Hash` of identifier components.
 
@@ -118,7 +125,6 @@ end
 
 `String`, a 14-digit timestamp of the form 'YYYMMDDHHmmSS'. The release number of the package as determined by the packager of the software. If you provide this, you must also provide the version; with all four components, the match is guarenteed to be unique.
 
-
 ```ruby
 describe habitat_package(origin: 'core', name: 'httpd', version: '2.3.5', release: '20190307151146') do
   it { should exist }
@@ -137,7 +143,7 @@ end
 
 ## Properties
 
-Use [properties](https://www.inspec.io/docs/reference/glossary/#property) to create tests that compare an expected value to the actual value.
+Use [properties](/inspec/glossary/#property) to create tests that compare an expected value to the actual value.
 
 ### identifier
 
@@ -171,7 +177,7 @@ end
 
 ### pkg_id
 
-`String`. The full package identifier of the package, in the form `origin/name/version/release`.  See also [name](#name) and [version](#version).
+`String`. The full package identifier of the package, in the form `origin/name/version/release`. See also [name](#name) and [version](#version).
 
 ```ruby
 describe habitat_package(origin: 'core', name: 'httpd') do
@@ -191,7 +197,7 @@ end
 
 ### version
 
-`String`. The version of the package, as assigned by the maintainer of the package project.  While many versions are of the 3-digit form, there is no set rule, and exceptions are common. See also [release](#release).
+`String`. The version of the package, as assigned by the maintainer of the package project. While many versions are of the 3-digit form, there is no set rule, and exceptions are common. See also [release](#release).
 
 ```ruby
 describe habitat_package(origin: 'core', name: 'httpd') do
@@ -201,8 +207,8 @@ end
 
 ## Matchers
 
-Use [matchers](https://www.inspec.io/docs/reference/glossary/#matcher) to create tests that test a true or false question.
+Use [matchers](/inspec/glossary/#matcher) to create tests that test a true or false question.
 
-InSpec includes a number of [universal matchers](https://www.inspec.io/docs/reference/matchers/). See below for matchers specific to this resource.
+InSpec includes a number of [universal matchers](/inspec/matchers/). See below for matchers specific to this resource.
 
 This resource does not provide any resource-specific matchers.

--- a/docs/resources/habitat_packages.md
+++ b/docs/resources/habitat_packages.md
@@ -1,9 +1,16 @@
----
-title: About the habitat_packages Resource
-platform: habitat
----
++++
+title = "habitat_packages resource"
+draft = false
+platform = "habitat"
 
-# habitat_packages
+[menu]
+  [menu.inspec]
+    title = "habitat_packages"
+    identifier = "inspec/resources/habitat/habitat_packages.md habitat_packages resource"
+    parent = "inspec/resources/habitat"
++++
+
+[\[edit on GitHub\]](https://github.com/inspec/inspec-habitat/blob/master/docs/resources/habitat_packages.md)
 
 Use the `habitat_package` (singular) InSpec audit resource to perform in-depth auditing of a single package.
 
@@ -18,7 +25,6 @@ This resource, like all of the inspec-habitat resource pack, is in the early sta
 ### Connecting to Habitat
 
 To configure `inspec` to be able to communicate with Chef Habitat, be sure [to follow the instructions](https://github.com/inspec/inspec-habitat#configuring-inspec-to-reach-habitat) regarding configuring the connection options. This will prevent 'unsupported platform' errors.
-
 
 ## Examples
 
@@ -71,13 +77,13 @@ This resource was first available in version 0.1.0 of the resource pack.
 
 ## Resource Parameters
 
-[Resource parameters](https://www.inspec.io/docs/reference/glossary/#resource-parameter) are arguments passed to the resource in the control code.
+[Resource parameters](/inspec/glossary/#resource-parameter) are arguments passed to the resource in the control code.
 
 This resource does not accept resource parameters, which is typical for plural resources.
 
 ## Filter Criteria
 
-[Filter criteria](https://www.inspec.io/docs/reference/glossary/#filter-criteria) are used to select which packages you wish to examine. If no filter criteria are used, all packages are selected.
+[Filter criteria](/inspec/glossary/#filter-criteria) are used to select which packages you wish to examine. If no filter criteria are used, all packages are selected.
 
 ### name
 
@@ -125,7 +131,7 @@ end
 
 ## Properties
 
-Use [properties](https://www.inspec.io/docs/reference/glossary/#property) to create tests that compare an expected value to the actual value.
+Use [properties](/inspec/glossary/#property) to create tests that compare an expected value to the actual value.
 
 ### count
 
@@ -192,8 +198,8 @@ end
 
 ## Matchers
 
-Use [matchers](https://www.inspec.io/docs/reference/glossary/#matcher) to create tests that test a true or false question.
+Use [matchers](/inspec/glossary/#matcher) to create tests that test a true or false question.
 
-InSpec includes a number of [universal matchers](https://www.inspec.io/docs/reference/matchers/).
+InSpec includes a number of [universal matchers](/inspec/matchers/).
 
 This resource does not define any resource-specific matchers.

--- a/docs/resources/habitat_service.md
+++ b/docs/resources/habitat_service.md
@@ -1,9 +1,16 @@
----
-title: About the habitat_service Resource
-platform: habitat
----
++++
+title = "habitat_service resource"
+draft = false
+platform = "habitat"
 
-# habitat_service
+[menu]
+  [menu.inspec]
+    title = "habitat_service"
+    identifier = "inspec/resources/habitat/habitat_service.md habitat_service resource"
+    parent = "inspec/resources/habitat"
++++
+
+[\[edit on GitHub\]](https://github.com/inspec/inspec-habitat/blob/master/docs/resources/habitat_service.md)
 
 Use the `habitat_service` InSpec audit resource to test properties of a single Habitat service.
 
@@ -42,11 +49,11 @@ If you use the CLI interface without the API, unavailable properties will behave
 
 If the service is not found, then this resource behaves as follows:
 
- * `it { should exist }` will be a failing test. Check this test if you are unsure if the resource will exist; it is guaranteed to be reliable in the future.
- * `name` and `origin` will continue to return their values as set in the resource parameters. This allows output messaging to refer to the missing service clearly.
- * All other single-value properties will return nil.
- * All array and hash-valued properties will return empty objects.
- * All matchers will return false.
+- `it { should exist }` will be a failing test. Check this test if you are unsure if the resource will exist; it is guaranteed to be reliable in the future.
+- `name` and `origin` will continue to return their values as set in the resource parameters. This allows output messaging to refer to the missing service clearly.
+- All other single-value properties will return nil.
+- All array and hash-valued properties will return empty objects.
+- All matchers will return false.
 
 ## Availability
 
@@ -60,7 +67,7 @@ This resource was first available in version 0.1.0 of the resource pack.
 
 ## Resource Parameters
 
-Use [resource parameters](https://www.inspec.io/docs/reference/glossary/#resource-parameter) to identify the particular service you wish to test.
+Use [resource parameters](/inspec/glossary/#resource-parameter) to identify the particular service you wish to test.
 
 ### origin
 
@@ -92,7 +99,7 @@ end
 
 ## Properties
 
-Use [properties](https://www.inspec.io/docs/reference/glossary/#property) to create tests that compare an expected value to the actual value.
+Use [properties](/inspec/glossary/#property) to create tests that compare an expected value to the actual value.
 
 ### dependency_names
 
@@ -142,7 +149,7 @@ end
 
 ### pkg_id
 
-String. The full package identifier of the package that supports the service, in the form `origin/name/version/release`.  See also [name](#name) and [version](#version).
+String. The full package identifier of the package that supports the service, in the form `origin/name/version/release`. See also [name](#name) and [version](#version).
 
 ```ruby
 describe habitat_service(origin: 'core', name: 'httpd') do
@@ -162,7 +169,7 @@ end
 
 ### version
 
-The version of the package that supports the service, as assigned by the maintainer of the package project.  While many versions are of the 3-digit form, there is no set rule, and exceptions are common. See also [release](#release).
+The version of the package that supports the service, as assigned by the maintainer of the package project. While many versions are of the 3-digit form, there is no set rule, and exceptions are common. See also [release](#release).
 
 ```ruby
 describe habitat_service(origin: 'core', name: 'httpd') do
@@ -172,9 +179,9 @@ end
 
 ## Matchers
 
-Use [matchers](https://www.inspec.io/docs/reference/glossary/#matcher) to create tests that test a true or false question.
+Use [matchers](/inspec/glossary/#matcher) to create tests that test a true or false question.
 
-InSpec includes a number of [universal matchers](https://www.inspec.io/docs/reference/matchers/). See below for matchers specific to this resource.
+InSpec includes a number of [universal matchers](/inspec/matchers/). See below for matchers specific to this resource.
 
 ### have_standalone_topology
 

--- a/docs/resources/habitat_services.md
+++ b/docs/resources/habitat_services.md
@@ -1,9 +1,16 @@
----
-title: About the habitat_services Resource
-platform: habitat
----
++++
+title = "habitat_services resource"
+draft = false
+platform = "habitat"
 
-# habitat_services
+[menu]
+  [menu.inspec]
+    title = "habitat_services"
+    identifier = "inspec/resources/habitat/habitat_services.md habitat_services resource"
+    parent = "inspec/resources/habitat"
++++
+
+[\[edit on GitHub\]](https://github.com/inspec/inspec-habitat/blob/master/docs/resources/habitat_services.md)
 
 Use the `habitat_service` (singular) InSpec audit resource to perform in-depth auditing of a single service.
 
@@ -85,13 +92,13 @@ This resource was first available in version 0.1.0 of the resource pack.
 
 ## Resource Parameters
 
-[Resource parameters](https://www.inspec.io/docs/reference/glossary/#resource-parameter) are arguments passed to the resource in the control code.
+[Resource parameters](/inspec/glossary/#resource-parameter) are arguments passed to the resource in the control code.
 
 This resource does not accept resource parameters, which is typical for plural resources.
 
 ## Filter Criteria
 
-[Filter criteria](https://www.inspec.io/docs/reference/glossary/#filter-criteria) are used to select which services you wish to examine. If no filter criteria are used, all services are selected.
+[Filter criteria](/inspec/glossary/#filter-criteria) are used to select which services you wish to examine. If no filter criteria are used, all services are selected.
 
 ### dependency_names
 
@@ -175,7 +182,7 @@ end
 
 ## Properties
 
-Use [properties](https://www.inspec.io/docs/reference/glossary/#property) to create tests that compare an expected to value to the actual value.
+Use [properties](/inspec/glossary/#property) to create tests that compare an expected to value to the actual value.
 
 ### count
 
@@ -282,8 +289,8 @@ end
 
 ## Matchers
 
-Use [matchers](https://www.inspec.io/docs/reference/glossary/#matcher) to create tests that test a true or false question.
+Use [matchers](/inspec/glossary/#matcher) to create tests that test a true or false question.
 
-InSpec includes a number of [universal matchers](https://www.inspec.io/docs/reference/matchers/).
+InSpec includes a number of [universal matchers](/inspec/matchers/).
 
 This resource does not define any resource-specific matchers.


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>



## Description

This migrates changes to the inspec-habitat resources docs from `inspec/inspec` that were made so the resources could be added to docs.chef.io

After this is merged we can source the inspec resources docs from the `inspec/inspec-habitat` repo instead of keeping them in `inspec/inspec`.

## Related Issue

chef/release-engineering#984

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
